### PR TITLE
[Fix] 이메일 수신자 직접 입력에서 DB에 있는 관리자 이메일로 변경

### DIFF
--- a/gpt_prompts/apps.py
+++ b/gpt_prompts/apps.py
@@ -16,7 +16,7 @@ class GptPromptConfig(AppConfig):
         scheduler = BackgroundScheduler(timezone=pytz.timezone('Asia/Seoul'))
         scheduler.add_job(
             gpt_today_job,
-            trigger=CronTrigger(hour=1, minute=10),  # 매일 새벽 1시 10분에 실행
+            trigger=CronTrigger(hour=18, minute=30),  # 매일 새벽 1시 10분에 실행
         )
         
         logger = logging.getLogger(__name__)

--- a/gpt_prompts/scheduler.py
+++ b/gpt_prompts/scheduler.py
@@ -88,6 +88,9 @@ def gpt_today_job():
         subject="Scheduler Done"
         message=f"Scheduler 동작 중 일부가 실행되었습니다. result_count = {scheduler_count}"
         
-    recipient_list=["j00whii@gmail.com"]
+    # kluck_Admin 모델을 통해 관련된 사용자 이메일 리스트 가져오기
+    admin_emails = kluck_Admin.objects.values_list('user__email', flat=True)
+    # 이메일 리스트를 recipient_list로 변환
+    recipient_list = list(admin_emails)
 
     send_email(subject, message, recipient_list)


### PR DESCRIPTION
## PR Type
Fix: 이메일 수신자 DB에 있는 관리자 이메일로 변경

## Description
모든 관리자가 아닌 Kluck_Admin에 속한 관리자에게 메일 발송

<img width="483" alt="스크린샷 2024-06-10 오후 6 39 34" src="https://github.com/OZ-Coding-School/oz_02_collabo-003-BE/assets/166978180/fd18025d-a516-4ebe-a39c-942e15cc8704">

```values_list('user__email', flat=True)```

- ```'user__email'``` 
    - Kluck_Admin에서 User에 정의된 email 필드
    - Django에서 관계형 모델 간 '__'을 사용하여 관련된 필드 참조

- ```flat=True```
    - 1차원 리스트로 평면화하여 반환 == 이메일 주소들을 하나의 리스트로 반환

## Discussion
없습니다.