### PR TITLE
[BE] Fix: scheduler-time DB에서 변수 가져오기

### DIFF
--- a/Kluck_config/settings.py
+++ b/Kluck_config/settings.py
@@ -30,13 +30,13 @@ DEBUG = True
 # 온라인 서버에 배포 할때만 사용
 # ALLOWED_HOSTS = ['43.201.60.229']
 # 온라인 서버에서 Nginx, gunicorn 사용시에 사용
-# ALLOWED_HOSTS = [
-#     'kluck-dev.ap-northeast-2.elasticbeanstalk.com',
-#     'kluck-dev2.ap-northeast-2.elasticbeanstalk.com',
-#     'kluck.playfillit.com'
-# ]
+ALLOWED_HOSTS = [
+    'kluck-dev.ap-northeast-2.elasticbeanstalk.com',
+    'kluck-dev2.ap-northeast-2.elasticbeanstalk.com',
+    'kluck.playfillit.com'
+]
 # 개발 중에는 아래 내용을 사용
-ALLOWED_HOSTS = []
+# ALLOWED_HOSTS = []
 
 # Application definition
 

--- a/Kluck_config/settings.py
+++ b/Kluck_config/settings.py
@@ -30,13 +30,13 @@ DEBUG = True
 # 온라인 서버에 배포 할때만 사용
 # ALLOWED_HOSTS = ['43.201.60.229']
 # 온라인 서버에서 Nginx, gunicorn 사용시에 사용
-ALLOWED_HOSTS = [
-    'kluck-dev.ap-northeast-2.elasticbeanstalk.com',
-    'kluck-dev2.ap-northeast-2.elasticbeanstalk.com',
-    'kluck.playfillit.com'
-]
+# ALLOWED_HOSTS = [
+#     'kluck-dev.ap-northeast-2.elasticbeanstalk.com',
+#     'kluck-dev2.ap-northeast-2.elasticbeanstalk.com',
+#     'kluck.playfillit.com'
+# ]
 # 개발 중에는 아래 내용을 사용
-# ALLOWED_HOSTS = []
+ALLOWED_HOSTS = []
 
 # Application definition
 

--- a/gpt_prompts/apps.py
+++ b/gpt_prompts/apps.py
@@ -11,12 +11,25 @@ class GptPromptConfig(AppConfig):
     verbose_name = "GPT API를 이용한 오늘의 한마디 데이터 자동 저장"
 
     def ready(self):
+        from admin_settings.models import AdminSetting
         from .scheduler import gpt_today_job
+
+        # AdminSetting 테이블에서 term_time 가져오기
+        try:
+            scheduler_time = AdminSetting.objects.first().term_time
+            # 숫자 네자리를 문자열로 변환하여 분리
+            scheduler_time_str = str(scheduler_time).zfill(4)  # 네자리로 맞추기 위해 zfill 사용
+            hour = int(scheduler_time_str[:2])  # 앞 두 자리
+            minute = int(scheduler_time_str[2:])  # 뒤 두 자리
+        except AttributeError:
+            # 예외 처리: AdminSetting 객체가 없을 경우 기본값 설정
+            hour = 1
+            minute = 10
 
         scheduler = BackgroundScheduler(timezone=pytz.timezone('Asia/Seoul'))
         scheduler.add_job(
             gpt_today_job,
-            trigger=CronTrigger(hour=18, minute=30),  # 매일 새벽 1시 10분에 실행
+            trigger=CronTrigger(hour=hour, minute=minute),  # 매일 새벽 1시 10분에 실행
         )
         
         logger = logging.getLogger(__name__)

--- a/gpt_prompts/views.py
+++ b/gpt_prompts/views.py
@@ -161,6 +161,10 @@ class GptTodayLuck(APIView):
         # POST 요청의 body에서 입력한 일자 'date'를 추출
         request_date = request.data.get('date')
 
+        # success_count 변수값 초기화.
+        global success_count
+        success_count = 0
+
         # 각 카테고리별 GPT에게 질문하는 함수 실행.
         GptToday(request_date) # Success count = 1
         GptStar(request_date) # Success count = 2
@@ -173,7 +177,7 @@ class GptTodayLuck(APIView):
         if success_count == 15:
             return Response(f"{luck_date} 운세 데이터 생성을 완료 했습니다.", status=status.HTTP_200_OK)
         else:
-            return Response(f"{luck_date} 운세 데이터가 이미 있습니다.{success_count}", status=status.HTTP_200_OK)
+            return Response(f"{luck_date} 운세 데이터가 이미 있습니다.{success_count}", status=status.HTTP_206_PARTIAL_CONTENT)
         
 # 1. 오늘의 한마디 받기 함수
 def GptToday(request_date):
@@ -287,7 +291,7 @@ def GptToday(request_date):
             else:
                 return Response({'detail': '데이터가 없습니다.'},status=status.HTTP_400_BAD_REQUEST)
     else:
-        return Response({'luck_message_today': '이미 데이터가 있습니다.'},status=status.HTTP_202_ACCEPTED)
+        return Response({'luck_message_today': '이미 데이터가 있습니다.'},status=status.HTTP_206_PARTIAL_CONTENT)
     
 # 2. 별자리 운세 받기 함수
 def GptStar(request_date):
@@ -410,7 +414,7 @@ def GptStar(request_date):
                 return Response({'detail': '데이터가 없습니다.'},status=status.HTTP_400_BAD_REQUEST)
 
     else:
-        return Response({'luck_message_today': '이미 데이터가 있습니다.'},status=status.HTTP_202_ACCEPTED)
+        return Response({'luck_message_today': '이미 데이터가 있습니다.'},status=status.HTTP_206_PARTIAL_CONTENT)
     
 # 3. MBTI 운세 받기 함수
 def GptMbti(request_date):
@@ -525,7 +529,7 @@ def GptMbti(request_date):
                 return Response({'detail': '데이터가 없습니다.'},status=status.HTTP_400_BAD_REQUEST)
         
     else:
-        return Response({'luck_message_today': '이미 데이터가 있습니다.'},status=status.HTTP_202_ACCEPTED)
+        return Response({'luck_message_today': '이미 데이터가 있습니다.'},status=status.HTTP_206_PARTIAL_CONTENT)
     
 # 4. 띠별 운세 받기 함수
 def GptZodiac(request_date):
@@ -651,5 +655,5 @@ def GptZodiac(request_date):
             return Response(zodiac_prompt_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         # return Response(status=status.HTTP_200_OK)
     else:
-        return Response({'luck_message_today': '이미 데이터가 있습니다.'},status=status.HTTP_202_ACCEPTED)
+        return Response({'luck_message_today': '이미 데이터가 있습니다.'},status=status.HTTP_206_PARTIAL_CONTENT)
     


### PR DESCRIPTION
기존 scheduler에 hard coding으로 되어있던 시간을 admin_settings 테이블에 있는 term_time 값을 가져와 시간과 분 데이터로 받아서 작동하게 했습니다.

+) gpt 에게 질문 물어보는 api내 success_count 초기화 하는 코드 추가.