### PR TITLE
[BE] Add: period luck message

### DIFF
--- a/admin_settings/views.py
+++ b/admin_settings/views.py
@@ -99,7 +99,7 @@ class Terms(APIView):
             OpenApiExample(
                 'Example',
                 value={"term_date": "0030",
-                       "term_time": "0110"
+                        "term_time": "0110"
                 },
                 request_only=True,  # 요청 본문에서만 예시 사용
             )

--- a/admins/views.py
+++ b/admins/views.py
@@ -23,7 +23,7 @@ class JWTLogin(APIView):
         examples=[
             OpenApiExample(
                 'Example',
-                value={'username': 'admin', 'password': 'sksmsrhksflwk1'},
+                value={'username': 'admin1', 'password': 'sksmsrhksflwk1'},
                 request_only=True,  # 요청 본문에서만 예시 사용
             )
         ],

--- a/gpt_prompts/scheduler.py
+++ b/gpt_prompts/scheduler.py
@@ -43,90 +43,84 @@ def gpt_today_job():
     if not work_on:
         # 해당 일자 운세 작업을 이전에도 했는지 확인.
         worked = LuckMessage.objects.filter(category='work', luck_date=luck_date, attribute2=1).first()
+        # attribute2) 0 : '작업중', 1 : '작업완료'
+
         if not worked:  # 해당 일자 운세 생성 작업한 적이 없는 경우. (작업 확인 데이터 없는 경우)
             # 해당 일자 작업 확인 데이터 추가.
-            work_serializer = TodaySerializer(data={
-                'luck_date' : luck_date,
-                'category' : 'work',
-                'attribute2' : 0,
-                'gpt_id' : 1,
-            })
-
-            if work_serializer.is_valid():
-                work_serializer.save()
-            else:
-                raise ParseError(work_serializer.errors)
+            if not add_work_date(luck_date):
+                return Response(f"{luck_date} 운세 생성 작업을 확인하기 위한 데이터를 생성하는데 오류가 발생했습니다.",status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         else:   # 해당 일자 운세 생성 작업한 적이 있는 경우. (작업 확인 데이터 있는 경우)
             # 작업 확인 데이터에 '해당 일자 작업이 이루어지고 있다'로 수정.
-            work_again_serializer = TodaySerializer(worked, data={'attribute2' : 0}, partial=True)
-            if work_again_serializer.is_valid():
-                work_again_serializer.save()
+            if not update_work_date(worked):
+                return Response(f"{luck_date} 운세 생성 작업을 확인하기 위한 데이터를 업데이트하는데 오류가 발생했습니다.",status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # 각 카테고리별 GPT에게 질문하는 함수 실행.        
+        try:
+            Today = GptToday(luck_date)
+            if Today.status_code == status.HTTP_200_OK:
+                scheduler_count += 1
+                logging.info("GptToday 작업이 실행되었습니다.")
             else:
-                raise ParseError(work_again_serializer.errors)
+                logging.info("GptToday 작업이 실행되지 않았습니다.")
+        except Exception as e:
+            logging.error(f"GptToday 작업 실행 중 예외가 발생했습니다: {e}")
 
-    # 각 카테고리별 GPT에게 질문하는 함수 실행.        
-    try:
-        Today = GptToday(luck_date)
-        if Today.status_code == status.HTTP_200_OK:
-            scheduler_count += 1
-            logging.info("GptToday 작업이 실행되었습니다.")
-        else:
-            logging.info("GptToday 작업이 실행되지 않았습니다.")
-    except Exception as e:
-        logging.error(f"GptToday 작업 실행 중 예외가 발생했습니다: {e}")
+        try:
+            Star = GptStar(luck_date)
+            if Star.status_code == status.HTTP_200_OK:
+                scheduler_count += 2
+                logging.info("GptStar 작업이 실행되었습니다.")
+            else:
+                logging.info("GptStar 작업이 실행되지 않았습니다.")
+        except Exception as e:
+            logging.error(f"GptStar 작업 실행 중 예외가 발생했습니다: {e}")
 
-    try:
-        Star = GptStar(luck_date)
-        if Star.status_code == status.HTTP_200_OK:
-            scheduler_count += 2
-            logging.info("GptStar 작업이 실행되었습니다.")
-        else:
-            logging.info("GptStar 작업이 실행되지 않았습니다.")
-    except Exception as e:
-        logging.error(f"GptStar 작업 실행 중 예외가 발생했습니다: {e}")
+        try:
+            Mbti = GptMbti(luck_date)
+            if Mbti.status_code == status.HTTP_200_OK:
+                scheduler_count += 4
+                logging.info("GptMbti 작업이 실행되었습니다.")
+            else:
+                logging.info("GptMbti 작업이 실행되지 않았습니다.")
+        except Exception as e:
+            logging.error(f"GptMbti 작업 실행 중 예외가 발생했습니다: {e}")
 
-    try:
-        Mbti = GptMbti(luck_date)
-        if Mbti.status_code == status.HTTP_200_OK:
-            scheduler_count += 4
-            logging.info("GptMbti 작업이 실행되었습니다.")
-        else:
-            logging.info("GptMbti 작업이 실행되지 않았습니다.")
-    except Exception as e:
-        logging.error(f"GptMbti 작업 실행 중 예외가 발생했습니다: {e}")
+        try:
+            Zodiac = GptZodiac1(luck_date)
+            if Zodiac.status_code == status.HTTP_200_OK:
+                scheduler_count += 8
+                logging.info("GptZodiac 작업이 실행되었습니다.")
+            else:
+                logging.info("GptZodiac 작업이 실행되지 않았습니다.")
+        except Exception as e:
+            logging.error(f"GptZodiac 작업 실행 중 예외가 발생했습니다: {e}")
 
-    try:
-        Zodiac = GptZodiac(luck_date)
-        if Zodiac.status_code == status.HTTP_200_OK:
-            scheduler_count += 8
-            logging.info("GptZodiac 작업이 실행되었습니다.")
-        else:
-            logging.info("GptZodiac 작업이 실행되지 않았습니다.")
-    except Exception as e:
-        logging.error(f"GptZodiac 작업 실행 중 예외가 발생했습니다: {e}")
+        try:
+            Zodiac = GptZodiac2(luck_date)
+            if Zodiac.status_code == status.HTTP_200_OK:
+                scheduler_count += 16
+                logging.info("GptZodiac 작업이 실행되었습니다.")
+            else:
+                logging.info("GptZodiac 작업이 실행되지 않았습니다.")
+        except Exception as e:
+            logging.error(f"GptZodiac 작업 실행 중 예외가 발생했습니다: {e}")
 
-    # 작업이 전부 완료된 뒤 작업 확인 데이터 내용 '완료'로 수정.
-    work = LuckMessage.objects.filter(category='work', luck_date=luck_date).first()
-    done_serializer = TodaySerializer(work, data={
-        'attribute2': 1, 
-        'luck_msg' : f'Success count = {scheduler_count}',
-        'gpt_id' : 1}, partial=True)
-    if done_serializer.is_valid():
-        done_serializer.save()
-    else:
-        raise ParseError(done_serializer.errors)
+        # 작업이 전부 완료된 뒤 작업 확인 데이터 내용 '완료'로 수정.
+        work = LuckMessage.objects.filter(category='work', luck_date=luck_date).first()
+        if not update_done_date(work, scheduler_count):
+            return Response(f"{luck_date} 운세 생성 작업 확인 데이터를 완료로 업데이트하는데 오류가 발생했습니다.",status=status.HTTP_500_INTERNAL_SERVER_ERROR)
     
-    # 스케줄러가 다 동작된 이후 메일 전송.
-    # 전부 다 작동시 success count 합 15, 이 외 일부만 작동시 해당 success count 확인하여 작동된 함수 유추 가능.
-    if scheduler_count == 15:
-        subject="Scheduler Success Perfectly"
-        message="Scheduler 동작이 완벽하게 실행되었습니다."
-    elif scheduler_count == 0:
-        subject="Scheduler Fail"
-        message="Scheduler 동작 중 오류가 발생했습니다. 또는, 이미 해당 일자 운세 데이터가 있습니다."
-    else:
-        subject="Scheduler Done"
-        message=f"Scheduler 동작 중 일부가 실행되었습니다. result_count = {scheduler_count}"
+        # 스케줄러가 다 동작된 이후 메일 전송.
+        # 전부 다 작동시 success count 합 31, 이 외 일부만 작동시 해당 success count 확인하여 작동된 함수 유추 가능.
+        if scheduler_count == 31:
+            subject="Scheduler Success Perfectly"
+            message="Scheduler 동작이 완벽하게 실행되었습니다."
+        elif scheduler_count == 0:
+            subject="Scheduler Fail"
+            message="Scheduler 동작 중 오류가 발생했습니다. 또는, 이미 해당 일자 운세 데이터가 있습니다."
+        else:
+            subject="Scheduler Done"
+            message=f"Scheduler 동작 중 일부가 실행되었습니다. result_count = {scheduler_count}"
         
     # kluck_Admin 모델을 통해 관련된 사용자 이메일 리스트 가져오기
     admin_emails = kluck_Admin.objects.values_list('user__email', flat=True)

--- a/gpt_prompts/urls_gpt.py
+++ b/gpt_prompts/urls_gpt.py
@@ -3,6 +3,7 @@ from .views import *
 
 urlpatterns = [
     path('luck/', GptTodayLuck.as_view(), name='GptTodayLuck'),
+    path('luck/terms/', GptLuckPeriod.as_view(), name='GptLuckPeriod'),
     # path('today/', GptToday.as_view(), name='GptToday'),
     # path('zodiac/', GptZodiac.as_view(), name='GptZodiac'),
     # path('star/', GptStar.as_view(), name='GptStar'),

--- a/luck_messages/views.py
+++ b/luck_messages/views.py
@@ -38,8 +38,6 @@ class TodayLuck(APIView):
             else:
                 today_serializer = {'새벽 공기처럼 맑고 상쾌한 기운이 가득하길.🍃✨ 마음 가득 행복이 채워지는 날 되세요.🌷'}
 
-            today_msg = LuckMessage.objects.filter(luck_date=today, category='today')
-
 
             # 사용자 출생연도에 맞는 띠별 오늘의 운세 제공.
             user_zodiac = user_birth[:4]


### PR DESCRIPTION
제목은 Add: period luck message이지만 변경사항이 많은,,, PR입니다.🥲

1. GptZodiac 함수 2개로 분할
  - 기존 하나에서 for문으로 돌리려다 보니 GPT가 과부화 되어 가끔 동작하지 않는 것을 발견하고 수정 (bug)

2. 전역 변수 Success_count를 함수로 전환하여 겹쳐서 count 되지 않도록 수정
  - 기존 전역 변수로 작동시 여러 날짜를 특정 일자 생성으로 여러개 날리면 success_count가 중복으로 세졌다. 이를 해결 (bug), (enhancement)

3. gpt model을 일부 카테고리 운세에서 변경. (today, star)
  - 기존에 사용하던 gpt 4.0은 가장 최신의 버전이 아니어서 가장 최신 버전인 4o로 변경해서 사용해봄.
  -> 확실히 속도가 빨랐다...!
  - 다만, 기존에 길들이고 교육시켰던 gpt4.0과 달리 운세 메지 응답을 가져오는 것이 우리가 원하는 형태로 잘 못가져왔다.
  - 그래서 오류가 자주 발생한 mbti와 zodiac에서는 기존의 모델로 사용하는 것으로 변경.

4. 기간 단위로 운세 받는 /api/v1/gpt/luck/terms/ API URL 추가
  - 현재 4일정도까지 테스트 해봤는데
  - 오늘은 시간이 너무 늦어서...
  - 내일 마저 더 긴 기간을 테스트 해보기로 하는걸로 ㅠㅠ

+) 스케줄러 잘 작동하는지 확인 필요,,, 새벽 12시는 00시로 입력되어 작동 안되는 것을 확인.
다만 새벽 1시 시간대에서는 작동했지만 로컬 서버에서 작동한건지 원격 서버에서 작동한건지 불확실.
따라서 제가 지금 일부러 2시 50분으로 설정해놨는데 밤새 작동했는지 내일 확인해봐야 할거 같아요.
# 시간 바꾸지 말아주세요!!!!!!