### PR TITLE
[Feat] 푸시 스케줄러 및 디바이스 토큰 요청 API 로그 저장

### DIFF
--- a/kluck_notifications/apps.py
+++ b/kluck_notifications/apps.py
@@ -1,8 +1,12 @@
 from django.apps import AppConfig
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+import logging
 import pytz
 
+
+# 푸시 로거 가져오기
+push_logger = logging.getLogger('push_jobs')
 
 class KluckNotificationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
@@ -22,6 +26,7 @@ class KluckNotificationsConfig(AppConfig):
             minute = int(push_time_str[2:])  # 뒤 두 자리
         except AttributeError:
             # 예외 처리: AdminSetting 객체가 없을 경우 기본값 설정
+            push_logger.warning("AdminSetting 객체가 없어 기본값으로 설정합니다.")
             hour = 8
             minute = 0
 
@@ -37,6 +42,9 @@ class KluckNotificationsConfig(AppConfig):
         )
 
         try:
+            push_logger.info("Starting Push scheduler...")
             push_scheduler.start()
         except KeyboardInterrupt:
+            push_logger.warning("Stopping Push scheduler...")
             push_scheduler.shutdown()
+            push_logger.warning("Push scheduler shut down successfully!")

--- a/kluck_notifications/push_scheduler.py
+++ b/kluck_notifications/push_scheduler.py
@@ -5,13 +5,32 @@ from django.utils import timezone
 from datetime import datetime, timedelta
 from .models import DeviceToken
 from luck_messages.models import LuckMessage
+import logging
+
+# 푸시 알림 로그 따로 쌓기
+# logger instence 생성
+push_logger = logging.getLogger('push_jobs')
+# log level 설정
+push_logger.setLevel(logging.INFO)
+# 파일 핸들러 생성
+file_handler = logging.FileHandler('push_jobs.log')
+push_logger.addHandler(file_handler)
+# 포맷 설정
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(funcName)s:%(lineno)s - %(message)s')
+file_handler.setFormatter(formatter)
 
 # push 보내는 함수
 def send_push_notifications():
     # firebase adminsdk 초기화
     cred_path = 'kluck_notifications/kluck-firebase.json'
-    cred = credentials.Certificate(cred_path)
-    firebase_admin.initialize_app(cred) # 초기화 한번만
+    try:
+        cred = credentials.Certificate(cred_path)
+        firebase_admin.initialize_app(cred) # 초기화 한번만
+        push_logger.info("Firebase Admin SDK 초기화 성공")
+    except Exception as e:
+        push_logger.error(f"Firebase Admin SDK 초기화 실패: {e}")
+        return
+
 
     try:
         # DB에서 디바이스 토큰 가져오기
@@ -51,20 +70,27 @@ def send_push_notifications():
 
             # Firebase로 푸시 알림 전송
             response = messaging.send_multicast(message)
+            push_logger.info(f"푸시 알림 발송 성공. Response: {response}")
+        else:
+            push_logger.info(f"오늘의 운세 메시지가 존재하지 않습니다. today_luck_msg: {today_luck_msg}")
             
     except Exception as e:
-        print(f"푸시 알림 전송 중 오류 발생: {e}")
+        push_logger.error(f"푸시 알림 전송 중 오류 발생: {e}")
 
 # 비활성화 토큰 삭제하기
 def remove_inactive_tokens():
-    # 비환성화 토큰 삭제 기준 날짜 (FCM 공식 문서 중 비활성 토큰 기간 참고 - 2개월)
-    deactive_date = timezone.now() - timedelta(days=60)
-    # 비활성화된 토큰 찾기 (update_time이 60일 초과했을 경우)
-    inactive_tokens = DeviceToken.objects.filter(update_date__lt=deactive_date) # __lt : 작은 값 비교 / __lte : 작거나 같은 값
-    # 비활성화 토큰 개수
-    count = inactive_tokens.count()
-    # 비활성화 토큰 삭제
-    inactive_tokens.delete()
-    
-    # 삭제된 비활성화 토큰 개수 출력
-    print(f'Deleted {count} inactive tokens')
+    try:
+        # 비환성화 토큰 삭제 기준 날짜 (FCM 공식 문서 중 비활성 토큰 기간 참고 - 2개월)
+        deactive_date = timezone.now() - timedelta(days=60)
+        # 비활성화된 토큰 찾기 (update_date가 60일 초과했을 경우)
+        inactive_tokens = DeviceToken.objects.filter(update_date__lt=deactive_date) # __lt : 작은 값 비교 / __lte : 작거나 같은 값
+        # 비활성화 토큰 개수
+        count = inactive_tokens.count()
+        # 비활성화 토큰 삭제
+        inactive_tokens.delete()
+        
+        # 삭제된 비활성화 토큰 개수 출력
+        push_logger.info(f'Deleted {count} inactive tokens')
+
+    except Exception as e:
+        push_logger.error(f"비활성화 토큰 삭제 중 오류 발생: {e}")

--- a/kluck_notifications/views.py
+++ b/kluck_notifications/views.py
@@ -7,6 +7,12 @@ from django.utils import timezone
 from .models import *
 from.serializers import *
 
+import logging
+
+# 푸시 로거 가져오기
+push_logger = logging.getLogger('push_jobs')
+
+
 # push 알림을 위한 토큰 받아오기
 class PushToken(APIView):
     permission_classes = (AllowAny,)
@@ -26,6 +32,7 @@ class PushToken(APIView):
     )
     
     def post(self, request):
+        push_logger.info(f"PushToken API에 POST 요청이 들어왔습니다. data: {request.data}")
         serializer = DeviceTokenSerializer(data=request.data)
 
         if serializer.is_valid(): # 유효한 데이터일 경우, 데이터 추출
@@ -37,10 +44,13 @@ class PushToken(APIView):
 
             if not token_exists: # 토큰이 중복되지 않는 경우, 토큰 저장
                 serializer.save()
+                push_logger.info(f"새로운 토큰이 저장되었습니다: {token}")
                 return Response({'message': '토큰이 저장되었습니다.'}, status=status.HTTP_201_CREATED)
-            else: # 토큰이 중복되는 경우, update_time 갱신
+            else: # 토큰이 중복되는 경우, update_date 갱신
                 token_exists.update_date = timezone.now()
                 token_exists.save()
+                push_logger.info(f"기존 토큰이 갱신되었습니다: {token}")
                 return Response({'message': '토큰이 갱신되었습니다.'}, status=status.HTTP_200_OK)
         else:
+            push_logger.error(f"유효하지 않은 데이터가 POST 요청에서 받아졌습니다. error: {serializer.errors}")
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## PR Type
Feat: 푸시 스케줄러 및 디바이스 토큰 요청 API 로그를 push_jobs.log 파일에 별도 저장

## Description

- logging 시, gpt_jobs.log로 로그가 쌓이길래 push_jobs.log 파일을 만들어 로그 독립적으로 저장

<img width="646" alt="스크린샷 2024-06-18 오전 9 54 27" src="https://github.com/OZ-Coding-School/oz_02_collabo-003-BE/assets/166978180/e6474be4-50c4-4943-b919-2b821c3a8871">


- 디바이스 토큰 요청 API 로그도 push_jobs.log에 저장

<img width="309" alt="스크린샷 2024-06-18 오전 9 56 08" src="https://github.com/OZ-Coding-School/oz_02_collabo-003-BE/assets/166978180/035d4953-0320-417f-9391-982296d66859">
