### PR TITLE
[BE] Fix: gpt ai 스케줄러 -> crontab 이용

### DIFF
--- a/Kluck_config/settings.py
+++ b/Kluck_config/settings.py
@@ -57,10 +57,10 @@ CUSTOM_APPS = [
     'rest_framework',
     # JWT Token
     'rest_framework_simplejwt',
-    # 스웨거API
-    'drf_spectacular',
-    # scheduler
-    'django_apscheduler',
+    # # 스웨거API
+    # 'drf_spectacular',
+    # # scheduler
+    # 'django_apscheduler',
     # django-crontab
     "django_crontab",
     # 각종 설정값 테이블
@@ -164,6 +164,12 @@ LOGGING = {
             'filename': os.path.join(BASE_DIR, 'logs/device_token_cron.log'),
             'formatter': 'verbose',
         },
+        'file_gpt_ai': {
+            'level' : 'INFO',
+            'class' : 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'logs/gpt_ai_cron.log'),
+            'formatter': 'verbose',
+        }
     },
     'loggers': {
         'push_jobs': {
@@ -173,6 +179,11 @@ LOGGING = {
         },
         'device_token': {
             'handlers': ['file_device_token'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'gpt_ai': {
+            'handlers': ['file_gpt_ai'],
             'level': 'INFO',
             'propagate': True,
         },
@@ -276,4 +287,5 @@ CRONJOBS = [
     # ('* * * * *', 'kluck_notifications.cron.hi', f'>> {os.path.join(BASE_DIR, "logs/hi_cron.log")} 2>&1'),
     ('* * * * *', 'kluck_notifications.cron.push_cron_job', f'>> {os.path.join(BASE_DIR, "logs/push_cron.log")} 2>&1'), # 매 분마다 실행 -> push_scheduler
     ('0 0 * * *', 'kluck_notifications.cron.remove_inactive_tokens', f'>> {os.path.join(BASE_DIR, "logs/device_token_cron.log")} 2>&1'), # 매일 0시 0분 실행 -> inactive
+    ('* * * * *', 'gpt_prompts.cron.gpt_ai_cron_job', f'>> {os.path.join(BASE_DIR, "logs/gpt_ai_cron.log")} 2>&1'), # 매 분마다 실행 -> gpt_ai_scheduler
 ]

--- a/Kluck_config/settings.py
+++ b/Kluck_config/settings.py
@@ -57,8 +57,8 @@ CUSTOM_APPS = [
     'rest_framework',
     # JWT Token
     'rest_framework_simplejwt',
-    # # 스웨거API
-    # 'drf_spectacular',
+    # 스웨거API
+    'drf_spectacular',
     # # scheduler
     # 'django_apscheduler',
     # django-crontab

--- a/gpt_prompts/apps.py
+++ b/gpt_prompts/apps.py
@@ -1,47 +1,5 @@
 from django.apps import AppConfig
-from django.conf import settings
-from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.cron import CronTrigger
-import logging
-import pytz
 
 class GptPromptConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "gpt_prompts"
-    verbose_name = "GPT API를 이용한 오늘의 한마디 데이터 자동 저장"
-
-    # def ready(self):
-        # 스케줄러 초기화 다른 곳으로 옮겨 지연시키기
-        # self.initialize_scheduler()
-
-    def initialize_scheduler(self):
-        from .scheduler import gpt_today_job
-        from admin_settings.models import AdminSetting
-
-        # AdminSetting 테이블에서 term_time 가져오기
-        try:
-            scheduler_time = AdminSetting.objects.first().term_time
-            # 숫자 네자리를 문자열로 변환하여 분리
-            scheduler_time_str = str(scheduler_time).zfill(4)  # 네자리로 맞추기 위해 zfill 사용
-            hour = int(scheduler_time_str[:2])  # 앞 두 자리
-            minute = int(scheduler_time_str[2:])  # 뒤 두 자리
-        except AttributeError:
-            # 예외 처리: AdminSetting 객체가 없을 경우 기본값 설정
-            hour = 1
-            minute = 10
-
-        scheduler = BackgroundScheduler(timezone=pytz.timezone('Asia/Seoul'))
-        scheduler.add_job(
-            gpt_today_job,
-            trigger=CronTrigger(hour=hour, minute=minute),  # 매일 새벽 1시 10분에 실행
-        )
-        
-        logger = logging.getLogger(__name__)
-
-        try:
-            logger.info("Starting scheduler...")
-            scheduler.start()
-        except KeyboardInterrupt:
-            logger.info("Stopping scheduler...")
-            scheduler.shutdown()
-            logger.info("Scheduler shut down successfully!")

--- a/gpt_prompts/cron.py
+++ b/gpt_prompts/cron.py
@@ -1,0 +1,42 @@
+from django.utils import timezone
+from datetime import datetime, timedelta
+from .scheduler import gpt_today_job
+from .models import GptPrompt
+from admin_settings.models import AdminSetting
+import logging
+import pytz
+
+# gpt ai 로거
+gpt_ai_logger = logging.getLogger('gpt_ai_jobs')
+
+# GPT AI를 이용해 운세 받아오기
+def gpt_ai_cron_job():
+    """
+    매분마다 관리자 페이지에서 설정한 term_time과 현재 시각(한국 기준)을 비교한 후,
+    현재 시각이 term_time과 같으면 '현재 일자(한국 기준) + term_date'일자의 운세를 gpt ai를 통해 받아온다.
+    """
+    
+    # DB에서 term_time, term_date 가져오기
+    try:
+        term_time = AdminSetting.objects.first().term_time
+        # # 숫자 네자리를 문자열로 변환하여 분리
+        # scheduler_time_str = str(scheduler_time).zfill(4)  # 네자리로 맞추기 위해 zfill 사용
+        # hour = int(scheduler_time_str[:2])  # 앞 두 자리
+        # minute = int(scheduler_time_str[2:])  # 뒤 두 자리
+    except AttributeError:
+        term_time = "0110"  # 기본값 오전 1시 10분
+        
+    # 현재 시각
+    current_time = datetime.now(pytz.timezone('Asia/Seoul'))
+    # 현재 시각과 push_time 같은 형식으로 맞추기
+    current_time_str = current_time.strftime('%H%M')
+
+    # 현재 시각과 term_time이 같으면 gpt ai에게 질문 전송.
+    if current_time_str == term_time:
+        try:
+            gpt_today_job()
+            gpt_ai_logger.info(f"현재 시각: {current_time_str} | 발송 시간: {term_time} => Gpt AI가 동작할 시간입니다.")
+        except Exception as e:
+            gpt_ai_logger.error(f"Gpt AI 작동 중 오류 발생: {e}")
+    else:
+        gpt_ai_logger.info(f"현재 시각: {current_time_str} | 발송 시간: {term_time} => Gpt AI가 동작할 시간이 아닙니다.")

--- a/gpt_prompts/scheduler.py
+++ b/gpt_prompts/scheduler.py
@@ -4,11 +4,15 @@ from django.shortcuts import get_object_or_404
 from luck_messages.models import LuckMessage
 from luck_messages.serializers import *
 from .views import *
-import logging
 from datetime import datetime, timedelta
+import logging
+import os
 
-# 로깅 기본 설정: 로그 레벨, 로그 포맷, 파일 이름 등을 지정할 수 있습니다.
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', filename='gpt_jobs.log')
+# Django 프로젝트의 루트 디렉토리 경로
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# gpt_ai 로거 가져오기
+gpt_ai_logger = logging.getLogger('gpt_ai')
 
 # 이메일 전송 함수
 def send_email(subject, message, recipient_list):
@@ -21,10 +25,10 @@ def send_email(subject, message, recipient_list):
             recipient_list=recipient_list,
             fail_silently=False,
         )
-        logging.info(f"이메일이 성공적으로 전송되었습니다. 수신자: {recipient_list}, 제목: {subject}")
+        gpt_ai_logger.info(f"Gpt AI 운세 생성 이메일이 성공적으로 전송되었습니다. 수신자: {recipient_list}, 제목: {subject}")
         print("Email send successfully")
     except Exception as e:
-        logging.info(f"이메일 전송 중 오류가 발생했습니다: {e}")
+        gpt_ai_logger.info(f"Gpt AI 운세 생성 이메일 전송 중 오류가 발생했습니다: {e}")
         print(f"Email send failed: {e}")
 
 # 주요 작업 함수
@@ -60,51 +64,51 @@ def gpt_today_job():
             Today = GptToday(luck_date)
             if Today.status_code == status.HTTP_200_OK:
                 scheduler_count += 1
-                logging.info("GptToday 작업이 실행되었습니다.")
+                gpt_ai_logger.info("GptToday 작업이 실행되었습니다.")
             else:
-                logging.info("GptToday 작업이 실행되지 않았습니다.")
+                gpt_ai_logger.info("GptToday 작업이 실행되지 않았습니다.")
         except Exception as e:
-            logging.error(f"GptToday 작업 실행 중 예외가 발생했습니다: {e}")
+            gpt_ai_logger.error(f"GptToday 작업 실행 중 예외가 발생했습니다: {e}")
 
         try:
             Star = GptStar(luck_date)
             if Star.status_code == status.HTTP_200_OK:
                 scheduler_count += 2
-                logging.info("GptStar 작업이 실행되었습니다.")
+                gpt_ai_logger.info("GptStar 작업이 실행되었습니다.")
             else:
-                logging.info("GptStar 작업이 실행되지 않았습니다.")
+                gpt_ai_logger.info("GptStar 작업이 실행되지 않았습니다.")
         except Exception as e:
-            logging.error(f"GptStar 작업 실행 중 예외가 발생했습니다: {e}")
+            gpt_ai_logger.error(f"GptStar 작업 실행 중 예외가 발생했습니다: {e}")
 
         try:
             Mbti = GptMbti(luck_date)
             if Mbti.status_code == status.HTTP_200_OK:
                 scheduler_count += 4
-                logging.info("GptMbti 작업이 실행되었습니다.")
+                gpt_ai_logger.info("GptMbti 작업이 실행되었습니다.")
             else:
-                logging.info("GptMbti 작업이 실행되지 않았습니다.")
+                gpt_ai_logger.info("GptMbti 작업이 실행되지 않았습니다.")
         except Exception as e:
-            logging.error(f"GptMbti 작업 실행 중 예외가 발생했습니다: {e}")
+            gpt_ai_logger.error(f"GptMbti 작업 실행 중 예외가 발생했습니다: {e}")
 
         try:
             Zodiac = GptZodiac1(luck_date)
             if Zodiac.status_code == status.HTTP_200_OK:
                 scheduler_count += 8
-                logging.info("GptZodiac 작업이 실행되었습니다.")
+                gpt_ai_logger.info("GptZodiac 작업이 실행되었습니다.")
             else:
-                logging.info("GptZodiac 작업이 실행되지 않았습니다.")
+                gpt_ai_logger.info("GptZodiac 작업이 실행되지 않았습니다.")
         except Exception as e:
-            logging.error(f"GptZodiac 작업 실행 중 예외가 발생했습니다: {e}")
+            gpt_ai_logger.error(f"GptZodiac 작업 실행 중 예외가 발생했습니다: {e}")
 
         try:
             Zodiac = GptZodiac2(luck_date)
             if Zodiac.status_code == status.HTTP_200_OK:
                 scheduler_count += 16
-                logging.info("GptZodiac 작업이 실행되었습니다.")
+                gpt_ai_logger.info("GptZodiac 작업이 실행되었습니다.")
             else:
-                logging.info("GptZodiac 작업이 실행되지 않았습니다.")
+                gpt_ai_logger.info("GptZodiac 작업이 실행되지 않았습니다.")
         except Exception as e:
-            logging.error(f"GptZodiac 작업 실행 중 예외가 발생했습니다: {e}")
+            gpt_ai_logger.error(f"GptZodiac 작업 실행 중 예외가 발생했습니다: {e}")
 
         # 작업이 전부 완료된 뒤 작업 확인 데이터 내용 '완료'로 수정.
         work = LuckMessage.objects.filter(category='work', luck_date=luck_date).first()

--- a/kluck_notifications/push_scheduler.py
+++ b/kluck_notifications/push_scheduler.py
@@ -1,7 +1,6 @@
 import firebase_admin # Firebase Admin SDK 사용
 from firebase_admin import credentials # 서비스 계정 키를 사용하여 Firebase Admin SDK 인증
 from firebase_admin import messaging # FCM 메시지 생성 및 전송
-# from django.utils import timezone
 from datetime import datetime, timedelta
 from .models import DeviceToken
 from luck_messages.models import LuckMessage


### PR DESCRIPTION
### PR Type
Fix: 기존에 사용하던  apscheduler에서 crontab 이용으로 변경.

### Description
1. gpt_prompts 폴더 내 cron.py 파일 만들어 gpt ai에게 질문하는 시간인 term_time과 현재 시간을 비교하는 cron 작성
2. settings.py에 위 함수 실행시키는 코드 및 해당 작업에 대한 로그 기록되는 코드 작성
3. 기존 gpt_prompts 폴더 내 apps.py에 있는 스케줄러 실행 코드 삭제.
4. settings.py에 스케줄러 관련 모듈 주석 처리.

### Discussion
- settings.py에 있는 스케줄러 관련 모듈 및 pyproject, requirements.txt에 있는 모듈도 삭제할 것인지,
- 원격 서버에서 기존 작성되던 로그 파일들 (gpt_job.log, push_jobs.log) 삭제할 것인지.